### PR TITLE
Fix crash on empty directories, fix directory listing logic, fix in ReadMe

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
     - bodyclose
     - dogsled
     - errcheck
-    - exportloopref
     - gochecknoinits
     - goconst
     - gocritic

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ paru -S fm-bin
 - `fm update` will update fm to the latest version
 - `fm --start-dir=/some/start/dir` will start fm in the specified directory
 - `fm --selection-path=/tmp/tmpfile` will write the selected items path to the selection path when pressing <kbd>E</kbd> and exit fm
-- `fm --start-dir=/some/dir` start fm at a specific directory
 - `fm --enable-logging=true` start fm with logging enabled
 - `fm --pretty-markdown=true` render markdown using glamour to make it look nice
 - `fm --theme=default` set the theme of fm

--- a/filetree/commands.go
+++ b/filetree/commands.go
@@ -152,7 +152,11 @@ func (m Model) GetDirectoryListingCmd(directoryName string) tea.Cmd {
 			isSymlink := fileInfo.Mode()&os.ModeSymlink != 0
 
 			if isSymlink {
-				symlinkPath, _ := filepath.EvalSymlinks(filepath.Join(directoryPath, file.Name()))
+				symlinkPath, err := filepath.EvalSymlinks(filepath.Join(directoryPath, file.Name()))
+				if err != nil {
+					// This could be due to symlinks pointing to invalid path
+					continue
+				}
 				filePath = symlinkPath
 				symlinkInfo, err := os.Stat(symlinkPath)
 				if err != nil {

--- a/filetree/update.go
+++ b/filetree/update.go
@@ -173,6 +173,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				return m, nil
 			}
 
+			if len(m.files) == 0 {
+				return m, nil
+			}
+
 			if m.files[m.Cursor].IsDirectory {
 				return m, m.GetDirectoryListingCmd(m.files[m.Cursor].Path)
 			}


### PR DESCRIPTION
- Prevent crash on pressing right key on empty directories
- Fixes empty directory listing in case of the current directory had invalid symlinks.
- See comments of Issue #115 for more info.

Fixes 
- Issue #115 

---

Before
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/1d8e1f87-8fc6-44fa-b8c0-7d77c500a626" />
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/c103d26d-4869-4b8e-a857-893a2d45f9f0" />

After
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/74de23ef-2863-4270-98e8-7fe9ef09bb9a" />

